### PR TITLE
Config.uk: Fix dependencies with libunwind

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -1,6 +1,5 @@
 menuconfig LIBCXXABI
     bool "libcxxabi - c++ abi"
-    select LIBUNWIND
     default n
 
 if LIBCXXABI


### PR DESCRIPTION
`libcxxabi` and `libunwind` create circular dependencies.
Since libraries like `libcompiler-rt` and `cxx` depend on `libunwind`, it's more intuitive to remove the `libcxxabi` requirement of `libunwind` and make `libunwind` select `libcxxabi`.

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>