### PR TITLE
Bump version to 16.0.3 (C++17 support)

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -36,7 +36,7 @@
 $(eval $(call addlib_s,libcxxabi,$(CONFIG_LIBCXXABI)))
 
 ifeq ($(CONFIG_LIBCXXABI),y)
-ifneq ($(CONFIG_LIBLLVMUNWIND),y)
+ifneq ($(CONFIG_LIBUNWIND),y)
 $(error Require libunwind)
 endif
 endif
@@ -44,7 +44,7 @@ endif
 ################################################################################
 # Sources
 ################################################################################
-LIBCXXABI_VERSION=16.0.0
+LIBCXXABI_VERSION=16.0.3
 LIBCXXABI_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-$(LIBCXXABI_VERSION)/libcxxabi-$(LIBCXXABI_VERSION).src.tar.xz
 LIBCXXABI_PATCHDIR=$(LIBCXXABI_BASE)/patches
 $(eval $(call fetch,libcxxabi,$(LIBCXXABI_URL)))

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -48,6 +48,7 @@ LIBCXXABI_VERSION=16.0.0
 LIBCXXABI_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-$(LIBCXXABI_VERSION)/libcxxabi-$(LIBCXXABI_VERSION).src.tar.xz
 LIBCXXABI_PATCHDIR=$(LIBCXXABI_BASE)/patches
 $(eval $(call fetch,libcxxabi,$(LIBCXXABI_URL)))
+$(eval $(call patch,libcxxabi,$(LIBCXXABI_PATCHDIR),libcxxabi-$(LIBCXXABI_VERSION).src))
 
 ################################################################################
 # Helpers

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -36,7 +36,7 @@
 $(eval $(call addlib_s,libcxxabi,$(CONFIG_LIBCXXABI)))
 
 ifeq ($(CONFIG_LIBCXXABI),y)
-ifneq ($(CONFIG_LIBUNWIND),y)
+ifneq ($(CONFIG_LIBLLVMUNWIND),y)
 $(error Require libunwind)
 endif
 endif
@@ -44,8 +44,8 @@ endif
 ################################################################################
 # Sources
 ################################################################################
-LIBCXXABI_VERSION=7.0.0
-LIBCXXABI_URL=http://releases.llvm.org/$(LIBCXXABI_VERSION)/libcxxabi-$(LIBCXXABI_VERSION).src.tar.xz
+LIBCXXABI_VERSION=16.0.0
+LIBCXXABI_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-$(LIBCXXABI_VERSION)/libcxxabi-$(LIBCXXABI_VERSION).src.tar.xz
 LIBCXXABI_PATCHDIR=$(LIBCXXABI_BASE)/patches
 $(eval $(call fetch,libcxxabi,$(LIBCXXABI_URL)))
 
@@ -60,43 +60,50 @@ LIBCXXABI_SRC=$(LIBCXXABI_ORIGIN)/$(LIBCXXABI_SUBDIR)
 ################################################################################
 CINCLUDES-$(CONFIG_LIBCXXABI) += -I$(LIBCXXABI_SRC)/src
 CINCLUDES-$(CONFIG_LIBCXXABI) += -I$(LIBCXXABI_SRC)/include
+
 CXXINCLUDES-$(CONFIG_LIBCXXABI) += -I$(LIBCXXABI_SRC)/src
 CXXINCLUDES-$(CONFIG_LIBCXXABI) += -I$(LIBCXXABI_SRC)/include
 
 ################################################################################
 # Global flags
 ################################################################################
-ifndef CONFIG_LIBCXXABI_THREADS
-CONFIG_FLAGS	+=	-D _LIBCXXABI_HAS_NO_THREADS
-endif
-LIBCXXABI_CFLAGS-y    +=  $(CONFIG_FLAGS)
-LIBCXXABI_CXXFLAGS-y    +=  $(CONFIG_FLAGS)
+LIBCXXABI_CONFIG_FLAGS += -D_LIBCPP_BUILDING_LIBRARY
+LIBCXXABI_CONFIG_FLAGS += -D_LIBCXXABI_BUILDING_LIBRARY
+LIBCXXABI_CONFIG_FLAGS += -D__STDC_CONSTANT_MACROS
+LIBCXXABI_CONFIG_FLAGS += -D__STDC_FORMAT_MACROS
+LIBCXXABI_CONFIG_FLAGS += -D__STDC_LIMIT_MACROS
+LIBCXXABI_CONFIG_FLAGS += -D__linux__
 
-LIBCXXABI_SUPPRESS_FLAGS += -Wno-unused-parameter -Wno-parentheses
+ifndef ($(CONFIG_LIBCXXABI_THREADS),y)
+LIBCXXABI_CONFIG_FLAGS += -D _LIBCXXABI_HAS_NO_THREADS
+endif
+
+LIBCXXABI_SUPPRESS_FLAGS += -Wno-parentheses
+
+LIBCXXABI_CFLAGS-y   += $(LIBCXXABI_CONFIG_FLAGS)
+LIBCXXABI_CXXFLAGS-y += $(LIBCXXABI_CONFIG_FLAGS) -std=c++2a
+
 LIBCXXABI_CFLAGS-y   += $(LIBCXXABI_SUPPRESS_FLAGS)
 LIBCXXABI_CXXFLAGS-y += $(LIBCXXABI_SUPPRESS_FLAGS)
 
 ################################################################################
 # Library sources
 ################################################################################
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/abort_message.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_aux_runtime.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_default_handlers.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_demangle.cpp
 LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_exception.cpp
 LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_exception_storage.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_virtual.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/abort_message.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/stdlib_exception.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_demangle.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/stdlib_typeinfo.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/fallback_malloc.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_aux_runtime.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/stdlib_new_delete.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_personality.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_vector.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/stdlib_stdexcept.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_unexpected.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/private_typeinfo.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_handlers.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_default_handlers.cpp
 LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_guard.cpp
-ifdef CONFIG_LIBCXXABI_THREADS
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_thread_atexit.cpp
-endif
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_handlers.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_personality.cpp
+LIBCXXABI_SRCS-$(CONFIG_LIBCXXABI_THREADS) += $(LIBCXXABI_SRC)/src/cxa_thread_atexit.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_vector.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_virtual.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/fallback_malloc.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/private_typeinfo.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/stdlib_exception.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/stdlib_new_delete.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/stdlib_stdexcept.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/stdlib_typeinfo.cpp

--- a/patches/0001-cxa_guard_impl_syscall.patch
+++ b/patches/0001-cxa_guard_impl_syscall.patch
@@ -1,0 +1,41 @@
+Index: src/cxa_guard_impl.h
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/src/cxa_guard_impl.h b/src/cxa_guard_impl.h
+--- a/src/cxa_guard_impl.h	
++++ b/src/cxa_guard_impl.h	(date 1680688700108)
+@@ -60,6 +60,7 @@
+ #include <cstring>
+ #include <limits.h>
+ #include <stdlib.h>
++#include <uk/syscall.h>
+ 
+ #ifndef _LIBCXXABI_HAS_NO_THREADS
+ #  if defined(__ELF__) && defined(_LIBCXXABI_LINK_PTHREAD_LIB)
+@@ -161,7 +162,7 @@
+ #elif defined(SYS_gettid) && defined(_LIBCPP_HAS_THREAD_API_PTHREAD)
+ uint32_t PlatformThreadID() {
+   static_assert(sizeof(pid_t) == sizeof(uint32_t), "");
+-  return static_cast<uint32_t>(syscall(SYS_gettid));
++  return static_cast<uint32_t>(uk_syscall_static(SYS_gettid));
+ }
+ #else
+ constexpr uint32_t (*PlatformThreadID)() = nullptr;
+@@ -414,13 +415,13 @@
+ #if defined(SYS_futex)
+ void PlatformFutexWait(int* addr, int expect) {
+   constexpr int WAIT = 0;
+-  syscall(SYS_futex, addr, WAIT, expect, 0);
++  uk_syscall_static(SYS_futex, addr, WAIT, expect, 0);
+   __tsan_acquire(addr);
+ }
+ void PlatformFutexWake(int* addr) {
+   constexpr int WAKE = 1;
+   __tsan_release(addr);
+-  syscall(SYS_futex, addr, WAKE, INT_MAX);
++  uk_syscall_static(SYS_futex, addr, WAKE, INT_MAX);
+ }
+ #else
+ constexpr void (*PlatformFutexWait)(int*, int) = nullptr;


### PR DESCRIPTION
Updated libcxxabi to the latest upstream version; based off earlier work from @mschlumpp .
Part of a patch set w/ further PRs under [libcxx](https://github.com/unikraft/lib-libcxx/pull/27), [lib-compiler-rt](https://github.com/unikraft/lib-compiler-rt/pull/11), [libunwind](https://github.com/unikraft/lib-libunwind/pull/6) & [lib-musl](https://github.com/unikraft/lib-musl/pull/45).