### PR TITLE
Update to LLVM 14 (C++17 support)

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -1,8 +1,11 @@
 #  libcxxabi Makefile.uk
 #
 #  Authors: Vlad-Andrei Badoiu <vlad_andrei.badoiu@stud.acs.upb.ro>
+#           Marco Schlumpp <marco@unikraft.io>
+#           Andrei Tatar <andrei@unikraft.io>
 #
 #  Copyright (c) 2019, Politehnica University of Bucharest. All rights reserved.
+#  Copyright (c) 2023, Unikraft GmbH and The Unikraft Authors.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions
@@ -44,8 +47,8 @@ endif
 ################################################################################
 # Sources
 ################################################################################
-LIBCXXABI_VERSION=7.0.0
-LIBCXXABI_URL=http://releases.llvm.org/$(LIBCXXABI_VERSION)/libcxxabi-$(LIBCXXABI_VERSION).src.tar.xz
+LIBCXXABI_VERSION=14.0.6
+LIBCXXABI_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-$(LIBCXXABI_VERSION)/libcxxabi-$(LIBCXXABI_VERSION).src.tar.xz
 LIBCXXABI_PATCHDIR=$(LIBCXXABI_BASE)/patches
 $(eval $(call fetch,libcxxabi,$(LIBCXXABI_URL)))
 
@@ -60,19 +63,29 @@ LIBCXXABI_SRC=$(LIBCXXABI_ORIGIN)/$(LIBCXXABI_SUBDIR)
 ################################################################################
 CINCLUDES-$(CONFIG_LIBCXXABI) += -I$(LIBCXXABI_SRC)/src
 CINCLUDES-$(CONFIG_LIBCXXABI) += -I$(LIBCXXABI_SRC)/include
+
 CXXINCLUDES-$(CONFIG_LIBCXXABI) += -I$(LIBCXXABI_SRC)/src
 CXXINCLUDES-$(CONFIG_LIBCXXABI) += -I$(LIBCXXABI_SRC)/include
 
 ################################################################################
 # Global flags
 ################################################################################
-ifndef CONFIG_LIBCXXABI_THREADS
-CONFIG_FLAGS	+=	-D _LIBCXXABI_HAS_NO_THREADS
-endif
-LIBCXXABI_CFLAGS-y    +=  $(CONFIG_FLAGS)
-LIBCXXABI_CXXFLAGS-y    +=  $(CONFIG_FLAGS)
+LIBCXXABI_CONFIG_FLAGS += -D_LIBCPP_BUILDING_LIBRARY
+LIBCXXABI_CONFIG_FLAGS += -D_LIBCXXABI_BUILDING_LIBRARY
+LIBCXXABI_CONFIG_FLAGS += -D__STDC_CONSTANT_MACROS
+LIBCXXABI_CONFIG_FLAGS += -D__STDC_FORMAT_MACROS
+LIBCXXABI_CONFIG_FLAGS += -D__STDC_LIMIT_MACROS
+LIBCXXABI_CONFIG_FLAGS += -D__linux__
 
-LIBCXXABI_SUPPRESS_FLAGS += -Wno-unused-parameter -Wno-parentheses
+ifneq ($(CONFIG_LIBCXXABI_THREADS),y)
+LIBCXXABI_CONFIG_FLAGS += -D _LIBCXXABI_HAS_NO_THREADS
+endif
+
+LIBCXXABI_SUPPRESS_FLAGS += -Wno-parentheses
+
+LIBCXXABI_CFLAGS-y   += $(LIBCXXABI_CONFIG_FLAGS)
+LIBCXXABI_CXXFLAGS-y += $(LIBCXXABI_CONFIG_FLAGS)
+
 LIBCXXABI_CFLAGS-y   += $(LIBCXXABI_SUPPRESS_FLAGS)
 LIBCXXABI_CXXFLAGS-y += $(LIBCXXABI_SUPPRESS_FLAGS)
 
@@ -88,7 +101,7 @@ LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_exception_storage.cpp
 LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_guard.cpp
 LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_handlers.cpp
 LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_personality.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_unexpected.cpp
+LIBCXXABI_SRCS-$(CONFIG_LIBCXXABI_THREADS) += $(LIBCXXABI_SRC)/src/cxa_thread_atexit.cpp
 LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_vector.cpp
 LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_virtual.cpp
 LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/fallback_malloc.cpp
@@ -97,6 +110,3 @@ LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/stdlib_exception.cpp
 LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/stdlib_new_delete.cpp
 LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/stdlib_stdexcept.cpp
 LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/stdlib_typeinfo.cpp
-ifdef CONFIG_LIBCXXABI_THREADS
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_thread_atexit.cpp
-endif

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -79,24 +79,24 @@ LIBCXXABI_CXXFLAGS-y += $(LIBCXXABI_SUPPRESS_FLAGS)
 ################################################################################
 # Library sources
 ################################################################################
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/abort_message.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_aux_runtime.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_default_handlers.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_demangle.cpp
 LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_exception.cpp
 LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_exception_storage.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_virtual.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/abort_message.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/stdlib_exception.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_demangle.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/stdlib_typeinfo.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/fallback_malloc.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_aux_runtime.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/stdlib_new_delete.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_personality.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_vector.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/stdlib_stdexcept.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_unexpected.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/private_typeinfo.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_handlers.cpp
-LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_default_handlers.cpp
 LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_guard.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_handlers.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_personality.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_unexpected.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_vector.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_virtual.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/fallback_malloc.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/private_typeinfo.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/stdlib_exception.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/stdlib_new_delete.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/stdlib_stdexcept.cpp
+LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/stdlib_typeinfo.cpp
 ifdef CONFIG_LIBCXXABI_THREADS
 LIBCXXABI_SRCS-y += $(LIBCXXABI_SRC)/src/cxa_thread_atexit.cpp
 endif

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -51,6 +51,7 @@ LIBCXXABI_VERSION=14.0.6
 LIBCXXABI_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-$(LIBCXXABI_VERSION)/libcxxabi-$(LIBCXXABI_VERSION).src.tar.xz
 LIBCXXABI_PATCHDIR=$(LIBCXXABI_BASE)/patches
 $(eval $(call fetch,libcxxabi,$(LIBCXXABI_URL)))
+$(eval $(call patch,libcxxabi,$(LIBCXXABI_PATCHDIR),libcxxabi-$(LIBCXXABI_VERSION).src))
 
 ################################################################################
 # Helpers

--- a/patches/0001-cxa_guard_impl_syscall.patch
+++ b/patches/0001-cxa_guard_impl_syscall.patch
@@ -1,0 +1,37 @@
+diff --git a/libcxxabi/src/cxa_guard_impl.h b/libcxxabi/src/cxa_guard_impl.h
+index 72940cc7e..822765d89 100644
+--- a/src/cxa_guard_impl.h
++++ b/src/cxa_guard_impl.h
+@@ -56,6 +56,7 @@
+ 
+ #include <limits.h>
+ #include <stdlib.h>
++#include <uk/syscall.h>
+ #include <__threading_support>
+ #ifndef _LIBCXXABI_HAS_NO_THREADS
+ #  if defined(__ELF__) && defined(_LIBCXXABI_LINK_PTHREAD_LIB)
+@@ -157,7 +158,7 @@ uint32_t PlatformThreadID() {
+ #elif defined(SYS_gettid) && defined(_LIBCPP_HAS_THREAD_API_PTHREAD)
+ uint32_t PlatformThreadID() {
+   static_assert(sizeof(pid_t) == sizeof(uint32_t), "");
+-  return static_cast<uint32_t>(syscall(SYS_gettid));
++  return static_cast<uint32_t>(uk_syscall_static(SYS_gettid));
+ }
+ #else
+ constexpr uint32_t (*PlatformThreadID)() = nullptr;
+@@ -410,13 +411,13 @@ private:
+ #if defined(SYS_futex)
+ void PlatformFutexWait(int* addr, int expect) {
+   constexpr int WAIT = 0;
+-  syscall(SYS_futex, addr, WAIT, expect, 0);
++  uk_syscall_static(SYS_futex, addr, WAIT, expect, 0);
+   __tsan_acquire(addr);
+ }
+ void PlatformFutexWake(int* addr) {
+   constexpr int WAKE = 1;
+   __tsan_release(addr);
+-  syscall(SYS_futex, addr, WAKE, INT_MAX);
++  uk_syscall_static(SYS_futex, addr, WAKE, INT_MAX);
+ }
+ #else
+ constexpr void (*PlatformFutexWait)(int*, int) = nullptr;


### PR DESCRIPTION
Update libcxxabi to 14.0.6.
This is part of a patch set consisting of:
 - [libcxx](https://github.com/unikraft/lib-libcxx/pull/28)
 - [libcxxabi](https://github.com/unikraft/lib-libcxxabi/pull/4)
 - [lib-compiler-rt](https://github.com/unikraft/lib-compiler-rt/pull/12)
 - [libunwind](https://github.com/unikraft/lib-libunwind/pull/7)
 - [musl](https://github.com/unikraft/lib-musl/pull/45)
 - [unikraft/build](https://github.com/unikraft/unikraft/pull/881)

Tested with GCC 11, 12 & 13, and clang 16.
