### PR TITLE
Update to LLVM 21.1.1

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -47,7 +47,7 @@ endif
 ################################################################################
 # Sources
 ################################################################################
-LIBCXXABI_VERSION=14.0.6
+LIBCXXABI_VERSION=21.1.1
 LIBCXXABI_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-$(LIBCXXABI_VERSION)/libcxxabi-$(LIBCXXABI_VERSION).src.tar.xz
 LIBCXXABI_PATCHDIR=$(LIBCXXABI_BASE)/patches
 $(eval $(call fetch,libcxxabi,$(LIBCXXABI_URL)))

--- a/patches/0001-cxa_guard_impl_syscall.patch
+++ b/patches/0001-cxa_guard_impl_syscall.patch
@@ -1,37 +1,29 @@
 diff --git a/libcxxabi/src/cxa_guard_impl.h b/libcxxabi/src/cxa_guard_impl.h
-index 72940cc7e..822765d89 100644
+index 191a58917..571ee8b8f 100644
 --- a/src/cxa_guard_impl.h
 +++ b/src/cxa_guard_impl.h
-@@ -56,6 +56,7 @@
- 
- #include <limits.h>
- #include <stdlib.h>
-+#include <uk/syscall.h>
- #include <__threading_support>
- #ifndef _LIBCXXABI_HAS_NO_THREADS
- #  if defined(__ELF__) && defined(_LIBCXXABI_LINK_PTHREAD_LIB)
-@@ -157,7 +158,7 @@ uint32_t PlatformThreadID() {
- #elif defined(SYS_gettid) && defined(_LIBCPP_HAS_THREAD_API_PTHREAD)
+@@ -164,7 +164,7 @@ uint32_t PlatformThreadID() {
+ #elif defined(SYS_gettid) && _LIBCPP_HAS_THREAD_API_PTHREAD
  uint32_t PlatformThreadID() {
    static_assert(sizeof(pid_t) == sizeof(uint32_t), "");
 -  return static_cast<uint32_t>(syscall(SYS_gettid));
-+  return static_cast<uint32_t>(uk_syscall_static(SYS_gettid));
++  return static_cast<uint32_t>(uk_syscall(SYS_gettid));
  }
  #else
  constexpr uint32_t (*PlatformThreadID)() = nullptr;
-@@ -410,13 +411,13 @@ private:
- #if defined(SYS_futex)
+@@ -428,13 +428,13 @@ void PlatformFutexWake(int* addr) {
+ #elif defined(SYS_futex)
  void PlatformFutexWait(int* addr, int expect) {
    constexpr int WAIT = 0;
 -  syscall(SYS_futex, addr, WAIT, expect, 0);
-+  uk_syscall_static(SYS_futex, addr, WAIT, expect, 0);
++  uk_syscall(SYS_futex, addr, WAIT, expect, 0);
    __tsan_acquire(addr);
  }
  void PlatformFutexWake(int* addr) {
    constexpr int WAKE = 1;
    __tsan_release(addr);
 -  syscall(SYS_futex, addr, WAKE, INT_MAX);
-+  uk_syscall_static(SYS_futex, addr, WAKE, INT_MAX);
++  uk_syscall(SYS_futex, addr, WAKE, INT_MAX);
  }
  #else
  constexpr void (*PlatformFutexWait)(int*, int) = nullptr;


### PR DESCRIPTION
Update to lib-libcxxabi version 21.1.1

This PR is a part of a set of PRs:

- [lib-libcxx#37](https://github.com/unikraft/lib-libcxx/pull/37)
- [lib-libcxxabi#7](https://github.com/unikraft/lib-libcxxabi/pull/7)
- [lib-libunwind#12](https://github.com/unikraft/lib-libunwind/pull/12)
- [lib-compiler-rt#21](https://github.com/unikraft/lib-compiler-rt/pull/21)

Tested with `gcc 15.2.0` and `clang 19.1.4`